### PR TITLE
missing direct download links latest 2 data sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Each challenge will contain awesome prizes (cash and others) for the most effect
 | ---- | :------------------:| --------:| ---------------:| ------------:|:---------------:|:-------:|:---:|
 | 09/29/2016 | Sunny | 00:12:40 | 25G | 40G | [HTTP](http://bit.ly/udacity-dataset-2-1) | [Torrent](datasets/dataset.bag.tar.gz.torrent)| `33a10f7835068eeb29b2a3274c216e7d` |
 | 10/03/2016 | Overcast | 00:58:53 | 124G | 183G | [HTTP](http://bit.ly/udacity-dataset-2-2) | [Torrent](datasets/dataset-2-2.bag.tar.gz.torrent) | `34362e7d997476ed972d475b93b876f3` |
-| 10/10/2016 | Sunny | 03:20:02 | 21G | 23.3G | [HTTP]() | [Torrent](http://bit.ly/2dZTOcq) | `156fb6975060f60c452a9fa7c4121195` |
-| 10/20/2016 | Sunny | 03:30:00 | 30G | 40G | [HTTP]() | [Torrent](http://bit.ly/2epl7Ir ) | `13f107727bed0ee5731647b4e114a545` |
+| 10/10/2016 | Sunny | 03:20:02 | 21G | 23.3G |  | [Torrent](http://bit.ly/2dZTOcq) | `156fb6975060f60c452a9fa7c4121195` |
+| 10/20/2016 | Sunny | 03:30:00 | 30G | 40G |  | [Torrent](http://bit.ly/2epl7Ir ) | `13f107727bed0ee5731647b4e114a545` |
 
 Check out [udacity-driving-reader](https://github.com/rwightman/udacity-driving-reader) for some easy-to-use scripts to read or export to CSV or TensorFlow.
 


### PR DESCRIPTION
Just wanted to alert you that no HTTP direct download links exist for 20161010 & 20161020 data sets.  On empty links GitHub falls back to https://github.com/udacity/self-driving-car/blob/master.  This change removes the links.

If they exist, the working links can be added back.