### PR TITLE
Added `tf.reset_default_graph()` to reset model

### DIFF
--- a/steering-models/steering-node/steering_node.py
+++ b/steering-models/steering-node/steering_node.py
@@ -27,6 +27,7 @@ class SteeringNode(object):
                          buffer=np.array(d))[:,:,::-1]
         if self.image_lock.acquire(True):
             self.img = arr
+            tf.reset_default_graph()
             if self.model is None:
                 self.model = self.get_model()
             self.steering = self.predict(self.model, self.img)


### PR DESCRIPTION
I propose to add tf.reset_default_graph() at `line 30` to allow model run in a loop.

Reason:
- tf.reset_default_graph() to clear the default graph stack and resets the global default graph.  [here](https://www.tensorflow.org/api_docs/python/tf/reset_default_graph)

What happened before:
- Without using tf.reset_default_graph(), threading would run into error as following:

```shell
  Value Error: Fetch argument <tf.Tensor 'add_1:0' shape=(3,) dtype=int32> of
 <tf.Tensor 'add_1:0' shape=(3,) dtype=int32> cannot be interpreted as a Tensor.
 (Tensor Tensor("add_1:0", shape=(3,), dtype=int32) is not an element of this graph.)
```