### PR TITLE
Corrected the coordinate info of the CrowdAI dataset

### DIFF
--- a/annotations/README.md
+++ b/annotations/README.md
@@ -16,8 +16,8 @@ The dataset includes driving in Mountain View California and neighboring cities 
 #### CSV Format
 
 - xmin
-- xmax
 - ymin
+- xmax
 - ymax
 - frame
 - label


### PR DESCRIPTION
The order of the data in the CrowdAI dataset is xmin, ymin, xmax, ymax (as opposed to xmin, xmax, ymin, ymax as stated in the README and as the header row in the csv file falsely suggests). I corrected the README text and uploaded a corrected version of the csv file.