### PR TITLE
Two small changes to add support for TF 1.0 for YOLO (vehicle-detection/darkflow/)

### DIFF
--- a/vehicle-detection/darkflow/net/ops/convolution.py
+++ b/vehicle-detection/darkflow/net/ops/convolution.py
@@ -85,8 +85,8 @@ class convolutional(BaseOp):
                 'updates_collections' : None,
                 'is_training': layer.h['is_training']
                 })
-            v = tf.__version__.split('.')[1]
-            if int(v) < 12: key = 'initializers'
+            v = tf.__version__
+            if int(v) < 0.12: key = 'initializers'
             else: key = 'param_initializers'
             args.update({key : layer.w})
             return slim.batch_norm(inp, **args)

--- a/vehicle-detection/darkflow/net/ops/convolution.py
+++ b/vehicle-detection/darkflow/net/ops/convolution.py
@@ -85,8 +85,9 @@ class convolutional(BaseOp):
                 'updates_collections' : None,
                 'is_training': layer.h['is_training']
                 })
-            v = tf.__version__
-            if int(v) < 0.12: key = 'initializers'
+            v_ma = tf.__version__.split('.')[0]
+            v_mi = tf.__version__.split('.')[1]
+            if int(v_ma) < 1 & int(v_mi) < 12: key = 'initializers'
             else: key = 'param_initializers'
             args.update({key : layer.w})
             return slim.batch_norm(inp, **args)

--- a/vehicle-detection/darkflow/net/ops/simple.py
+++ b/vehicle-detection/darkflow/net/ops/simple.py
@@ -13,7 +13,7 @@ class route(BaseOp):
 				assert this is not None, \
 				'Routing to non-existence {}'.format(r)
 			routes_out += [this.out]	
-		self.out = tf.concat(3, routes_out)
+		self.out = tf.concat(axis=3, values=routes_out)
 
 	def speak(self):
 		msg = 'concat {}'


### PR DESCRIPTION
Added support for  TF 1.0 for YOLO detector for vehicle detection. By making 2 small changes in convolution.py and simple.py we ensure the code runs for all versions of TF:
- input order for tf.concat changed in TF 1.0
- if-statement in convolution.py was generic and didn't support >= 1.0