### PR TITLE
Fixed README formatting across the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="images/cover.png" alt="Self-Driving Car" width="800px">
 
-##We’re Building an Open Source Self-Driving Car
-####And we want your help!
+## We’re Building an Open Source Self-Driving Car
+#### And we want your help!
 
 At [Udacity](https://udacity.com), we believe in democratizing education. How can we provide opportunity to everyone on the planet? We also believe in teaching really amazing and useful subject matter. When we decided to build the [Self-Driving Car Nanodegree program](https://udacity.com/nd013), to teach the world to build autonomous vehicles, we instantly knew we had to tackle our own self-driving car too.
 

--- a/annotations/README.md
+++ b/annotations/README.md
@@ -34,7 +34,7 @@ The dataset includes driving in Mountain View California and neighboring cities 
 </tr>
 </table>
 
-###[Download](http://bit.ly/udacity-annoations-crowdai)
+### [Download](http://bit.ly/udacity-annoations-crowdai)
 
 
 ## Dataset 2 
@@ -71,4 +71,4 @@ This dataset is similar to dataset 1 but contains additional fields for occlusio
 </tr>
 </table>
 
-###[Download](http://bit.ly/udacity-annotations-autti)
+### [Download](http://bit.ly/udacity-annotations-autti)

--- a/challenges/README.md
+++ b/challenges/README.md
@@ -1,7 +1,7 @@
 <img src="../images/car.jpeg" alt="Self-Driving Car" width="800px">
 
-##We’re Building an Open Source Self-Driving Car
-####And we want your help!
+## We’re Building an Open Source Self-Driving Car
+#### And we want your help!
 
 Like any open source project, this code base will require a certain amount of thoughtfulness. However, when you add a 2-ton vehicle into the equation, we also need to make safety our absolute top priority, and pull requests just don’t cut it. To really optimize for safety, we’re breaking down the problem of making the car autonomous into **[Udacity Challenges](http://udacity.com/self-driving-car)**.
 

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -3,7 +3,7 @@ In an attempt to cleanup the data release practices of the Udacity Self-Driving 
 
 Check out [udacity-driving-reader](https://github.com/rwightman/udacity-driving-reader) for some easy-to-use scripts to read or export to CSV or TensorFlow.
 
-##Current Releases
+## Current Releases
 These releases should be issue/error free and comply with the new naming schema.
 
 #### Challenge 2 Driving Data
@@ -23,11 +23,11 @@ These releases should be issue/error free and comply with the new naming schema.
 |:----:|:-------:|
 | [CHX_001](https://github.com/udacity/self-driving-car/tree/master/datasets/CHX) | Lap around block at Udacity office with new HDL-32E LIDAR |
 
-##Legacy Data
+## Legacy Data
 
 [All torrent releases from Udacity can be found on our AcademicTorrents page with associated descriptions.](http://academictorrents.com/userdetails.php?id=5125) These releases are old and likely have issues that make them unsuitable for training, but many are useful. We will update legacy releases with more info as we move forward, but please use them only as a reference for now if you don't check them beforehand.
 
-####Driving Data
+#### Driving Data
 | Date | Lighting Conditions | Duration | Compressed Size | Uncompressed | Direct Download | Torrent | MD5 |
 | ---- | :------------------:| --------:| ---------------:| ------------:|:---------------:|:-------:|:---:|
 | 09/29/2016 | Sunny | 00:12:40 | 25G | 40G | [HTTP](http://bit.ly/udacity-dataset-2-1) | [Torrent](datasets/dataset.bag.tar.gz.torrent)| `33a10f7835068eeb29b2a3274c216e7d` |
@@ -35,5 +35,5 @@ These releases should be issue/error free and comply with the new naming schema.
 | 10/10/2016 | Sunny | 03:20:02 | 21G | 23.3G |  | [Torrent](http://bit.ly/2dZTOcq) | `156fb6975060f60c452a9fa7c4121195` |
 | 10/20/2016 | Sunny | 03:30:00 | 30G | 40G |  | [Torrent](http://bit.ly/2epl7Ir ) | `13f107727bed0ee5731647b4e114a545` |
 
-####Isolated and Trimmed Driving Data
+#### Isolated and Trimmed Driving Data
 With the help of [Auro Robotics](http://www.auro.ai/), compression, and selective recording, we now have considerably smaller datasets.

--- a/image-localization/README.md
+++ b/image-localization/README.md
@@ -1,6 +1,6 @@
-##Image-Based Localization
+## Image-Based Localization
 
 Here you will find code and documentation for community solutions to Udacity Challenge #3: Image-Based Localization. The `community-code` folder includes information about and code for the approaches that the finalists used, as well as reproduction instructions.
 
-##Safety
+## Safety
 This code is currently for research purposes only, and should not, at this time, be used in the operation of an actual vehicle. We have put the software together using ROS as a middleware, which allows you to use recorded data from a real vehicle to simulate how the software would perform on real roads without risk.

--- a/steering-models/README.md
+++ b/steering-models/README.md
@@ -1,6 +1,6 @@
-##Steering Models
+## Steering Models
 
 Here you will find code and documentation for community solutions to Udacity Challenge #2: Predicting Steering Angles. The `steering-node` folder includes the code we actually use on the vehicle to test models, the `community-models` folder includes information about the approaches to training and model building that the finalists used, and the "evaluation" folder includes links to the finalist models and associated scripts to test them on real image streams from the Udacity datasets.
 
-##Safety
+## Safety
 This code is currently for research purposes only, and should not, at this time, be used in the operation of an actual vehicle. We have put the software together using ROS as a middleware, which allows you to use recorded data from a real vehicle to simulate how the software would perform on real roads without risk.


### PR DESCRIPTION
Some headers weren't showing up correctly. This seems to either be a recent bug with Github or a change in Github flavored Markdown. Headers need to have a space betwen the #'s and the text. This is now fixed in every README file.